### PR TITLE
[update]エラー表示時に日本語にするためにpostcommentモデルのcommentを'コメント'に日本語化

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -263,3 +263,5 @@ ja:
         address: '住所'
         telephone_number: '電話番号'
         explanation: '説明'
+      postcomment:
+        comment: 'コメント'


### PR DESCRIPTION
エラー表示時に日本語にするために
postcommentモデルのcommentを'コメント'に日本語化